### PR TITLE
fix: set correct types path

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.js",
   "es2015": "./dist/esm/index.js",
-  "types": "./dist/types/index.d.ts",
+  "types": "./dist/types/src/index.d.ts",
   "scripts": {
     "build": "rm -rf ./dist && yarn tsc -p tsconfig.esm.json && yarn tsc && yarn tsc -p tsconfig.types.json",
     "test": "jest",


### PR DESCRIPTION
The types path inside the `package.json` file is not correct, making it difficult to use this package in typescript based projects